### PR TITLE
 make session constructor compatible with upstream library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tls-client"
-version = "1.1.0"
+version = "1.1.1"
 description = "Advanced Python HTTP Client."
 authors = [
     "Florian Zager <florian@zager-online.de>",

--- a/tls_client/adapters.py
+++ b/tls_client/adapters.py
@@ -10,7 +10,7 @@ from requests import Response
 from urllib3.util.retry import Retry
 from .cffi import request, freeMemory
 from .exceptions import TLSClientExeption
-from .config import TLSClientAdapterConfig
+from .config import TLSClientConfig
 # from ._compat.http_response import HTTPResponse
 from requests.structures import CaseInsensitiveDict
 from requests.cookies import extract_cookies_to_jar
@@ -25,7 +25,7 @@ class TLSClientAdapter(BaseAdapter):
         "config"
     ]
 
-    def __init__(self, config: TLSClientAdapterConfig, max_retries: int = DEFAULT_RETRIES):
+    def __init__(self, config: TLSClientConfig, max_retries: int = DEFAULT_RETRIES):
         super().__init__()
 
         self.config = config

--- a/tls_client/config.py
+++ b/tls_client/config.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict, List
 from .settings import ClientIdentifiers
 
 @dataclass
-class TLSClientAdapterConfig:
+class TLSClientConfig:
     # Examples:
     # Chrome --> chrome_103, chrome_104, chrome_105, chrome_106
     # Firefox --> firefox_102, firefox_104

--- a/tls_client/sessions.py
+++ b/tls_client/sessions.py
@@ -22,6 +22,50 @@ class Session(requests.Session):
         *args,
         **kwargs,  # for legacy support
     ) -> None:
+        """
+    Initialize the TLS client.
+
+    This constructor supports both the modern way of passing a `TLSClientConfig` object
+    and the legacy way using positional or keyword arguments. Legacy usage is deprecated
+    and will be removed in a future release.
+
+    :param config: Configuration for the TLS client. Can be either a `TLSClientConfig` instance
+                  or a legacy `client_identifier` string.
+    :type config: TLSClientConfig or str, optional
+    :param args: Positional arguments for legacy configuration.
+    :param kwargs: Additional keyword arguments. May include deprecated legacy fields
+                   or valid options such as `max_retries`.
+
+    :keyword int max_retries: Number of retries to use for the underlying TLS adapter.
+
+    .. deprecated:: 0.2.0
+        Using positional arguments or legacy keyword arguments is deprecated.
+        Please pass a `TLSClientConfig` instance instead.
+
+        The following legacy parameters are deprecated:
+
+        :keyword str client_identifier: Identifier of the TLS fingerprint preset (e.g., "chrome_112").
+        :keyword str ja3_string: Custom JA3 fingerprint string.
+        :keyword dict h2_settings: HTTP/2 SETTINGS frame values.
+        :keyword list h2_settings_order: Order of HTTP/2 SETTINGS keys.
+        :keyword list supported_signature_algorithms: Supported TLS signature algorithms.
+        :keyword list supported_delegated_credentials_algorithms: Delegated credentials algorithms.
+        :keyword list supported_versions: TLS versions to advertise.
+        :keyword list key_share_curves: Elliptic curves for key exchange.
+        :keyword str cert_compression_algo: Certificate compression algorithm.
+        :keyword bool additional_decode: Enable additional decoding logic.
+        :keyword list pseudo_header_order: Pseudo-header order for HTTP/2.
+        :keyword int connection_flow: HTTP/2 connection flow control value.
+        :keyword list priority_frames: HTTP/2 priority frame definitions.
+        :keyword list header_order: HTTP header order to send.
+        :keyword dict header_priority: Priority values for HTTP headers.
+        :keyword bool random_tls_extension_order: Randomize TLS extension order.
+        :keyword bool force_http1: Force HTTP/1.1 instead of HTTP/2.
+        :keyword bool catch_panics: Catch internal panics (used internally).
+        :keyword bool debug: Enable debug logging.
+        :keyword bool certificate_pinning: Enforce certificate pinning.
+        """
+        
         legacy_keys = [
             "client_identifier", "ja3_string", "h2_settings", "h2_settings_order",
             "supported_signature_algorithms", "supported_delegated_credentials_algorithms",

--- a/tls_client/sessions.py
+++ b/tls_client/sessions.py
@@ -3,7 +3,7 @@ from requests.structures import CaseInsensitiveDict
 from requests import Request, Response
 from collections import OrderedDict
 from .adapters import TLSClientAdapter
-from .config import TLSClientAdapterConfig
+from .config import TLSClientConfig
 from importlib.metadata import version
 from typing import Optional
 from json import dumps, loads
@@ -17,11 +17,11 @@ class Session(requests.Session):
 
     def __init__(
         self,
-        config: Optional[TLSClientAdapterConfig] = None,
+        config: Optional[TLSClientConfig] = None,
         **kwargs,  # for legacy support
     ) -> None:
         if config is None:
-            config = TLSClientAdapterConfig(**kwargs)
+            config = TLSClientConfig(**kwargs)
 
         self._session_id = str(uuid.uuid4())
         


### PR DESCRIPTION
Updated the session constructor to correctly handle both positional and named arguments, matching the behavior of the original library.